### PR TITLE
Support for foreign primary keys

### DIFF
--- a/src/test/scala/com/geirsson/codegen/CodegenTest.scala
+++ b/src/test/scala/com/geirsson/codegen/CodegenTest.scala
@@ -52,7 +52,7 @@ class CodegenTest extends FunSuite {
           |);
           |
           |create table article(
-          |  id integer not null,
+          |  id integer unique not null,
           |  article_unique_id uuid,
           |  author_id integer,
           |  is_published boolean
@@ -62,6 +62,18 @@ class CodegenTest extends FunSuite {
           |  ADD CONSTRAINT author_id_fk
           |  FOREIGN KEY (author_id)
           |  REFERENCES test_user (id);
+          |
+          |create table article_active(
+          |  article_id integer unique not null,
+          |  active boolean
+          |);
+          |
+          |ALTER TABLE article_active
+          |  ADD CONSTRAINT article_id_fk
+          |  FOREIGN KEY (article_id)
+          |  REFERENCES article (id);
+          |
+          |COMMENT ON TABLE article_active IS 'This is to demonstrate a foreign primary key.';
       """.stripMargin
     stmt.executeUpdate(sql)
     conn.close()

--- a/src/test/scala/com/geirsson/codegen/Tables.scala
+++ b/src/test/scala/com/geirsson/codegen/Tables.scala
@@ -16,6 +16,17 @@ object Tables {
   }
 
   /////////////////////////////////////////////////////
+  // ArticleActive
+  /////////////////////////////////////////////////////
+  case class ArticleActive(articleId: Article.Id, active: Option[ArticleActive.Active])
+  object ArticleActive {
+    def create(articleId: Int, active: Option[Boolean]): ArticleActive = {
+      ArticleActive(Article.Id(articleId), active.map(Active.apply))
+    }
+    case class Active(value: Boolean) extends AnyVal with WrappedValue[Boolean]
+  }
+
+  /////////////////////////////////////////////////////
   // TestUser
   /////////////////////////////////////////////////////
   case class TestUser(id: TestUser.Id, name: Option[TestUser.Name])


### PR DESCRIPTION
Adds support for primary key columns that are also a foreign key.

The old behavior was to generate `Id` types for each table.
New behavior is to generate only one `Id` type and use that type as the primary key of the referencing tables.