### PR TITLE
Add UUID, java.time, json and bytea types

### DIFF
--- a/src/main/scala/com/geirsson/codegen/Codegen.scala
+++ b/src/main/scala/com/geirsson/codegen/Codegen.scala
@@ -23,16 +23,13 @@ case class Error(msg: String) extends Exception(msg)
 @ProgName("db-codegen")
 case class CodegenOptions(
     @HelpMessage("user on database server") user: String = "postgres",
-    @HelpMessage("password for user on database server") password: String =
-      "postgres",
+    @HelpMessage("password for user on database server") password: String = "postgres",
     @HelpMessage("jdbc url") url: String = "jdbc:postgresql:postgres",
     @HelpMessage("schema on database") schema: String = "public",
-    @HelpMessage("only tested with postgresql") jdbcDriver: String =
-      "org.postgresql.Driver",
+    @HelpMessage("only tested with postgresql") jdbcDriver: String = "org.postgresql.Driver",
     @HelpMessage(
       "top level imports of generated file"
-    ) imports: String = """|import java.util.Date
-                           |import io.getquill.WrappedValue""".stripMargin,
+    ) imports: String = """import io.getquill.WrappedValue""",
     @HelpMessage(
       "package name for generated classes"
     ) `package`: String = "tables",
@@ -91,7 +88,7 @@ case class Codegen(options: CodegenOptions, namingStrategy: NamingStrategy) {
         val columns = getColumns(db, name, foreignKeys)
         val mappedColumns = columns.filter(_.isRight).map(_.right.get)
         val unmappedColumns = columns.filter(_.isLeft).map(_.left.get)
-        if (!unmappedColumns.isEmpty)
+        if (unmappedColumns.nonEmpty)
           warn(s"The following columns from table $name need a mapping: $unmappedColumns")
         Some(Table(
           name,
@@ -143,6 +140,7 @@ case class Codegen(options: CodegenOptions, namingStrategy: NamingStrategy) {
     s"""|package ${options.`package`}
         |${options.imports}
         |
+        |//noinspection ScalaStyle
         |object Tables {
         |$body
         |}

--- a/src/main/scala/com/geirsson/codegen/TypeMap.scala
+++ b/src/main/scala/com/geirsson/codegen/TypeMap.scala
@@ -28,7 +28,10 @@ object TypeMap {
     "varchar" -> "String",
     "serial" -> "Int",
     "bigserial" -> "Long",
-    "timestamp" -> "Date"
+    "timestamp" -> "java.util.Date",
+    "bytea" -> "Array[Byte]", // PostgreSQL
+    "uuid" -> "java.util.UUID", // H2, PostgreSQL
+    "json" -> "String" // PostgreSQL
   )
 }
 

--- a/src/test/scala/com/geirsson/codegen/Tables.scala
+++ b/src/test/scala/com/geirsson/codegen/Tables.scala
@@ -1,18 +1,28 @@
 package com.geirsson.codegen
-import java.util.Date
 import io.getquill.WrappedValue
 
+//noinspection ScalaStyle
 object Tables {
   /////////////////////////////////////////////////////
   // Article
   /////////////////////////////////////////////////////
-  case class Article(id: Article.Id, authorId: Option[TestUser.Id], isPublished: Option[Article.IsPublished])
+  case class Article(id: Article.Id,
+                     articleUniqueId: Option[Article.ArticleUniqueId],
+                     authorId: Option[TestUser.Id],
+                     isPublished: Option[Article.IsPublished])
   object Article {
-    def create(id: Int, authorId: Option[Int], isPublished: Option[Boolean]): Article = {
-      Article(Id(id), authorId.map(TestUser.Id.apply), isPublished.map(IsPublished.apply))
+    def create(id: Int,
+               articleUniqueId: Option[java.util.UUID],
+               authorId: Option[Int],
+               isPublished: Option[Boolean]): Article = {
+      Article(Id(id),
+              articleUniqueId.map(ArticleUniqueId.apply),
+              authorId.map(TestUser.Id.apply),
+              isPublished.map(IsPublished.apply))
     }
-    case class Id(value: Int)              extends AnyVal with WrappedValue[Int]
-    case class IsPublished(value: Boolean) extends AnyVal with WrappedValue[Boolean]
+    case class Id(value: Int)                         extends AnyVal with WrappedValue[Int]
+    case class ArticleUniqueId(value: java.util.UUID) extends AnyVal with WrappedValue[java.util.UUID]
+    case class IsPublished(value: Boolean)            extends AnyVal with WrappedValue[Boolean]
   }
 
   /////////////////////////////////////////////////////


### PR DESCRIPTION
Not sure if you like this change. I would suggest to use Java 8 LocalDateTime over the broken java.util.Date. One drawback is that quill does not yet support this out of the box, so you need to have something like this in scope to do the conversion:

```scala
  implicit val encodeDate = MappedEncoding[Date, LocalDateTime](d =>  LocalDateTime.ofInstant(Instant.ofEpochMilli(d.getTime), ZoneOffset.UTC) )
  implicit val decodeDate = MappedEncoding[LocalDateTime, Date](ldt => if (ldt != null) Date.from(ldt.toInstant(ZoneOffset.UTC)) else null)
```

Support for PostgreSQL `uuid`, `bytea` and `json` was also added.
Tests included for the UUID only.