### PR TITLE
Quill 1.0.1 support with java.time.

### DIFF
--- a/src/main/scala/com/geirsson/codegen/Codegen.scala
+++ b/src/main/scala/com/geirsson/codegen/Codegen.scala
@@ -29,7 +29,7 @@ case class CodegenOptions(
     @HelpMessage("only tested with postgresql") jdbcDriver: String = "org.postgresql.Driver",
     @HelpMessage(
       "top level imports of generated file"
-    ) imports: String = """import io.getquill.WrappedValue""",
+    ) imports: String = """""",
     @HelpMessage(
       "package name for generated classes"
     ) `package`: String = "tables",
@@ -140,8 +140,31 @@ case class Codegen(options: CodegenOptions, namingStrategy: NamingStrategy) {
     s"""|package ${options.`package`}
         |${options.imports}
         |
+        |/**
+        | * Generated using [[https://github.com/olafurpg/scala-db-codegen scala-db-codegen]]
+        | *  - Number of tables: ${tables.size}
+        | *  - Database URL: ${options.url}
+        | *  - Database schema: ${options.schema}
+        | *  - Database user: ${options.user}
+        | */
         |//noinspection ScalaStyle
         |object Tables {
+        |
+        |  /**
+        |    * Quill used to have this trait before v1, but it's still useful to keep.
+        |    * Examples are: pattern matching on wrapped type and conversion to JSON objects.
+        |    */
+        |  trait WrappedValue[T] extends Any with WrappedType { self: AnyVal =>
+        |    type Type = T
+        |    def value: T
+        |    override def toString = s"$$value"
+        |  }
+        |
+        |  trait WrappedType extends Any {
+        |    type Type
+        |    def value: Type
+        |  }
+        |
         |$body
         |}
      """.stripMargin

--- a/src/main/scala/com/geirsson/codegen/TypeMap.scala
+++ b/src/main/scala/com/geirsson/codegen/TypeMap.scala
@@ -28,7 +28,7 @@ object TypeMap {
     "varchar" -> "String",
     "serial" -> "Int",
     "bigserial" -> "Long",
-    "timestamp" -> "java.util.Date",
+    "timestamp" -> "java.time.LocalDateTime", // Since Quill 1.0.1, the scalajs-java-time library supports java time.
     "bytea" -> "Array[Byte]", // PostgreSQL
     "uuid" -> "java.util.UUID", // H2, PostgreSQL
     "json" -> "String" // PostgreSQL

--- a/src/test/scala/com/geirsson/codegen/CodegenTest.scala
+++ b/src/test/scala/com/geirsson/codegen/CodegenTest.scala
@@ -55,7 +55,8 @@ class CodegenTest extends FunSuite {
           |  id integer unique not null,
           |  article_unique_id uuid,
           |  author_id integer,
-          |  is_published boolean
+          |  is_published boolean,
+          |  published_at timestamp
           |);
           |
           |ALTER TABLE article

--- a/src/test/scala/com/geirsson/codegen/Tables.scala
+++ b/src/test/scala/com/geirsson/codegen/Tables.scala
@@ -1,28 +1,54 @@
 package com.geirsson.codegen
-import io.getquill.WrappedValue
 
+/**
+  * Generated using [[https://github.com/olafurpg/scala-db-codegen scala-db-codegen]]
+  *  - Number of tables: 3
+  *  - Database URL: jdbc:postgresql:postgres
+  *  - Database schema: scala_db_codegen
+  *  - Database user: postgres
+  */
 //noinspection ScalaStyle
 object Tables {
+
+  /**
+    * Quill used to have this trait before v1, but it's still useful to keep.
+    * Examples are: pattern matching on wrapped type and conversion to JSON objects.
+    */
+  trait WrappedValue[T] extends Any with WrappedType { self: AnyVal =>
+    type Type = T
+    def value: T
+    override def toString = s"$value"
+  }
+
+  trait WrappedType extends Any {
+    type Type
+    def value: Type
+  }
+
   /////////////////////////////////////////////////////
   // Article
   /////////////////////////////////////////////////////
   case class Article(id: Article.Id,
                      articleUniqueId: Option[Article.ArticleUniqueId],
                      authorId: Option[TestUser.Id],
-                     isPublished: Option[Article.IsPublished])
+                     isPublished: Option[Article.IsPublished],
+                     publishedAt: Option[Article.PublishedAt])
   object Article {
     def create(id: Int,
                articleUniqueId: Option[java.util.UUID],
                authorId: Option[Int],
-               isPublished: Option[Boolean]): Article = {
+               isPublished: Option[Boolean],
+               publishedAt: Option[java.time.LocalDateTime]): Article = {
       Article(Id(id),
               articleUniqueId.map(ArticleUniqueId.apply),
               authorId.map(TestUser.Id.apply),
-              isPublished.map(IsPublished.apply))
+              isPublished.map(IsPublished.apply),
+              publishedAt.map(PublishedAt.apply))
     }
-    case class Id(value: Int)                         extends AnyVal with WrappedValue[Int]
-    case class ArticleUniqueId(value: java.util.UUID) extends AnyVal with WrappedValue[java.util.UUID]
-    case class IsPublished(value: Boolean)            extends AnyVal with WrappedValue[Boolean]
+    case class Id(value: Int)                              extends AnyVal with WrappedValue[Int]
+    case class ArticleUniqueId(value: java.util.UUID)      extends AnyVal with WrappedValue[java.util.UUID]
+    case class IsPublished(value: Boolean)                 extends AnyVal with WrappedValue[Boolean]
+    case class PublishedAt(value: java.time.LocalDateTime) extends AnyVal with WrappedValue[java.time.LocalDateTime]
   }
 
   /////////////////////////////////////////////////////


### PR DESCRIPTION
Hi @olafurpg could you please review this PR?
I decided to copy the `WrappedValue` to the codegen because there is no other way to identify the type of the wrapped value (correct me if I'm wrong).